### PR TITLE
Skinny headerbar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ config.mk: configure
 
 -include config.mk
 
-RESOURCE_FILES := $(wildcard gtk/*.ui icon/*.svg)
+RESOURCE_FILES := $(wildcard gtk/*.ui gtk/*.css icon/*.svg)
 $(APP_ID).gresource: $(APP_ID).gresources.xml $(RESOURCE_FILES)
 	glib-compile-resources --target=$@ $<
 

--- a/gtk/custom.css
+++ b/gtk/custom.css
@@ -11,11 +11,11 @@
 
 .titlebar.revolt-slim separator,
 .titlebar.revolt-slim button {
-	margin-top: 3px;
-	margin-bottom: 3px;
+	margin: 3px 0 3px 0;
 }
 
 .titlebar.revolt-slim button {
 	min-height: 16px;
 	min-width: 18px;
+	padding: 3px 4px 3px 4px;
 }

--- a/gtk/custom.css
+++ b/gtk/custom.css
@@ -1,0 +1,21 @@
+/*
+ * custom.css
+ * Copyright (C) 2017 Adrian Perez
+ *
+ * Distributed under terms of the GPLv3 license.
+ */
+
+.titlebar.revolt-slim {
+	min-height: 0;
+}
+
+.titlebar.revolt-slim separator,
+.titlebar.revolt-slim button {
+	margin-top: 3px;
+	margin-bottom: 3px;
+}
+
+.titlebar.revolt-slim button {
+	min-height: 16px;
+	min-width: 18px;
+}

--- a/org.perezdecastro.Revolt.gresources.xml
+++ b/org.perezdecastro.Revolt.gresources.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <gresources>
 	<gresource prefix="/org/perezdecastro/Revolt">
+		<file compressed="true">gtk/custom.css</file>
 		<file preprocess="xml-stripblanks" compressed="true">gtk/menus-appmenu.ui</file>
 		<file preprocess="xml-stripblanks" compressed="true">gtk/preferences.ui</file>
 		<file preprocess="xml-stripblanks" compressed="true">icons/revolt-about.svg</file>

--- a/revolt/app.py
+++ b/revolt/app.py
@@ -7,7 +7,7 @@
 # Distributed under terms of the GPLv3 license.
 
 from os import environ
-from gi.repository import Gtk, Gio
+from gi.repository import Gtk, Gio, Gdk
 from .statusicon import StatusIcon
 from .window import MainWindow
 from . import accelerators
@@ -60,6 +60,10 @@ class RevoltApp(Gtk.Application):
         gtk_settings = Gtk.Settings.get_default()
         gtk_settings.set_property("gtk-dialogs-use-header",
                                   self.settings.get_boolean("use-header-bar"))
+        css_provider = Gtk.CssProvider()
+        css_provider.load_from_resource(self.get_resource_base_path() + "/gtk/custom.css")
+        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), css_provider,
+                                                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.statusicon = StatusIcon(self)
         self.__action("quit", lambda *arg: self.quit())
         self.__action("about", self.__on_app_about)

--- a/revolt/window.py
+++ b/revolt/window.py
@@ -82,6 +82,7 @@ class MainWindow(Gtk.ApplicationWindow):
     def __make_headerbar(self):
         header = Gtk.HeaderBar()
         header.set_show_close_button(True)
+        header.get_style_context().add_class("revolt-slim")
         spinner = Gtk.Spinner()
         header.pack_end(spinner)
         self.bind_property("network-busy", spinner, "active",


### PR DESCRIPTION
This reduces the amount of vertical space taken by the window header
bar. In turn, this leaves more space for Riot to display more content.

This is one of the improvements discussed in #2