### PR TITLE
Flatpak: Update to GNOME 3.34 Runtime

### DIFF
--- a/flatpak-builder-patches/libdbusmenu-build-fixes.diff
+++ b/flatpak-builder-patches/libdbusmenu-build-fixes.diff
@@ -1,0 +1,120 @@
+diff -ur libdbusmenu-16.04.0.orig/libdbusmenu-glib/Makefile.am libdbusmenu-16.04.0/libdbusmenu-glib/Makefile.am
+--- libdbusmenu-16.04.0.orig/libdbusmenu-glib/Makefile.am	2019-12-11 15:57:38.769791940 +0000
++++ libdbusmenu-16.04.0/libdbusmenu-glib/Makefile.am	2019-12-11 16:00:16.374963025 +0000
+@@ -66,7 +66,7 @@
+ libdbusmenu_glib_la_CFLAGS = \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GLIB\""
+ 
+ libdbusmenu_glib_la_LIBADD = \
+diff -ur libdbusmenu-16.04.0.orig/libdbusmenu-glib/Makefile.in libdbusmenu-16.04.0/libdbusmenu-glib/Makefile.in
+--- libdbusmenu-16.04.0.orig/libdbusmenu-glib/Makefile.in	2019-12-11 15:57:38.769791940 +0000
++++ libdbusmenu-16.04.0/libdbusmenu-glib/Makefile.in	2019-12-11 16:03:46.256566652 +0000
+@@ -498,7 +498,7 @@
+ libdbusmenu_glib_la_CFLAGS = \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall  -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GLIB\""
+ 
+ libdbusmenu_glib_la_LIBADD = \
+diff -ur libdbusmenu-16.04.0.orig/libdbusmenu-gtk/Makefile.am libdbusmenu-16.04.0/libdbusmenu-gtk/Makefile.am
+--- libdbusmenu-16.04.0.orig/libdbusmenu-gtk/Makefile.am	2019-12-11 15:57:38.765791911 +0000
++++ libdbusmenu-16.04.0/libdbusmenu-gtk/Makefile.am	2019-12-11 15:59:29.158608691 +0000
+@@ -66,7 +66,7 @@
+ 	$(DBUSMENUGTK_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+ 	-I$(top_srcdir) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GTK\""
+ 
+ libdbusmenu_gtk_la_LIBADD = \
+diff -ur libdbusmenu-16.04.0.orig/libdbusmenu-gtk/Makefile.in libdbusmenu-16.04.0/libdbusmenu-gtk/Makefile.in
+--- libdbusmenu-16.04.0.orig/libdbusmenu-gtk/Makefile.in	2019-12-11 15:57:38.765791911 +0000
++++ libdbusmenu-16.04.0/libdbusmenu-gtk/Makefile.in	2019-12-11 16:03:46.264566713 +0000
+@@ -507,7 +507,7 @@
+ 	$(DBUSMENUGTK_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+ 	-I$(top_srcdir) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall  -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GTK\""
+ 
+ libdbusmenu_gtk_la_LIBADD = \
+diff -ur libdbusmenu-16.04.0.orig/tests/Makefile.am libdbusmenu-16.04.0/tests/Makefile.am
+--- libdbusmenu-16.04.0.orig/tests/Makefile.am	2019-12-11 15:57:38.765791911 +0000
++++ libdbusmenu-16.04.0/tests/Makefile.am	2019-12-11 15:59:43.054712688 +0000
+@@ -103,7 +103,7 @@
+ ############################################
+ 
+ DBUSMENU_GLIB_TEST_CFLAGS = \
+-	-Wall -Werror \
++	-Wall \
+ 	-DG_DISABLE_DEPRECATED \
+ 	-I$(top_srcdir) \
+ 	$(DBUSMENUTESTS_CFLAGS) \
+diff -ur libdbusmenu-16.04.0.orig/tests/Makefile.in libdbusmenu-16.04.0/tests/Makefile.in
+--- libdbusmenu-16.04.0.orig/tests/Makefile.in	2019-12-11 15:57:38.765791911 +0000
++++ libdbusmenu-16.04.0/tests/Makefile.in	2019-12-11 16:03:46.244566559 +0000
+@@ -979,7 +979,7 @@
+ # Shared vars for the dbusmenu-glib tests
+ ############################################
+ DBUSMENU_GLIB_TEST_CFLAGS = \
+-	-Wall -Werror \
++	-Wall  \
+ 	-DG_DISABLE_DEPRECATED \
+ 	-I$(top_srcdir) \
+ 	$(DBUSMENUTESTS_CFLAGS) \
+diff -ur libdbusmenu-16.04.0.orig/tools/Makefile.am libdbusmenu-16.04.0/tools/Makefile.am
+--- libdbusmenu-16.04.0.orig/tools/Makefile.am	2019-12-11 15:57:38.761791881 +0000
++++ libdbusmenu-16.04.0/tools/Makefile.am	2019-12-11 15:59:53.942794342 +0000
+@@ -16,7 +16,7 @@
+ 	-I $(srcdir)/.. \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(DBUSMENUDUMPER_CFLAGS) \
+-	-Wall -Werror
++	-Wall
+ 
+ dbusmenu_dumper_LDADD = \
+ 	../libdbusmenu-glib/libdbusmenu-glib.la \
+diff -ur libdbusmenu-16.04.0.orig/tools/Makefile.in libdbusmenu-16.04.0/tools/Makefile.in
+--- libdbusmenu-16.04.0.orig/tools/Makefile.in	2019-12-11 15:57:38.761791881 +0000
++++ libdbusmenu-16.04.0/tools/Makefile.in	2019-12-11 16:03:46.252566621 +0000
+@@ -454,7 +454,7 @@
+ 	-I $(srcdir)/.. \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(DBUSMENUDUMPER_CFLAGS) \
+-	-Wall -Werror
++	-Wall 
+ 
+ dbusmenu_dumper_LDADD = \
+ 	../libdbusmenu-glib/libdbusmenu-glib.la \
+diff -ur libdbusmenu-16.04.0.orig/tools/testapp/Makefile.am libdbusmenu-16.04.0/tools/testapp/Makefile.am
+--- libdbusmenu-16.04.0.orig/tools/testapp/Makefile.am	2019-12-11 15:57:38.761791881 +0000
++++ libdbusmenu-16.04.0/tools/testapp/Makefile.am	2019-12-11 16:00:45.183180514 +0000
+@@ -12,7 +12,7 @@
+ 	-I $(srcdir)/../.. \
+ 	$(DBUSMENUTESTS_CFLAGS) \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+-	-Wall -Werror
++	-Wall
+ 
+ dbusmenu_testapp_LDADD = \
+ 	$(builddir)/../../libdbusmenu-glib/libdbusmenu-glib.la \
+diff -ur libdbusmenu-16.04.0.orig/tools/testapp/Makefile.in libdbusmenu-16.04.0/tools/testapp/Makefile.in
+--- libdbusmenu-16.04.0.orig/tools/testapp/Makefile.in	2019-12-11 15:57:38.761791881 +0000
++++ libdbusmenu-16.04.0/tools/testapp/Makefile.in	2019-12-11 16:03:46.248566590 +0000
+@@ -377,7 +377,7 @@
+ 	-I $(srcdir)/../.. \
+ 	$(DBUSMENUTESTS_CFLAGS) \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+-	-Wall -Werror
++	-Wall 
+ 
+ dbusmenu_testapp_LDADD = \
+ 	$(builddir)/../../libdbusmenu-glib/libdbusmenu-glib.la \

--- a/org.perezdecastro.Revolt.json
+++ b/org.perezdecastro.Revolt.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.perezdecastro.Revolt",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.28",
+  "runtime-version": "3.34",
   "sdk": "org.gnome.Sdk",
   "command": "revolt",
   "finish-args": [
@@ -40,6 +40,17 @@
   ],
   "modules": [
     {
+      "name": "intltool",
+      "cleanup": [ "*" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+          "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+        }
+      ]
+    },
+    {
       "name": "libdbusmenu",
       "build-options": {
         "env": {
@@ -60,6 +71,10 @@
           "type": "archive",
           "url": "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
           "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+        },
+        {
+          "type": "patch",
+          "path": "flatpak-builder-patches/libdbusmenu-build-fixes.diff"
         }
       ]
     },

--- a/revolt/window.py
+++ b/revolt/window.py
@@ -105,7 +105,6 @@ class MainWindow(Gtk.ApplicationWindow):
     def _web_context(self):
         print("Creating WebContext...")
         ctx = WebKit2.WebContext(website_data_manager=self._website_data_manager)
-        ctx.set_web_process_count_limit(1)
         ctx.set_spell_checking_enabled(False)
         ctx.set_tls_errors_policy(WebKit2.TLSErrorsPolicy.FAIL)
         return ctx


### PR DESCRIPTION
libdbusmenu would complain about intltool being too old. So the recipe now ships
a recent version of intltool. After fixing that, the libdbusmenu build would
still fail because they use -Werror and that triggers failures because
libdbusmenu uses deprecated GTK and GLib APIs. So the workaround is to disable
-Werror.