### PR TITLE
Allow to hide the window when pressing the close button.

### DIFF
--- a/org.perezdecastro.Revolt.gschema.xml
+++ b/org.perezdecastro.Revolt.gschema.xml
@@ -18,6 +18,10 @@
 			<summary>Whether to use a header bar. Disabling uses the decorations provided by the window manager.</summary>
 			<default>true</default>
 		</key>
+		<key name="hide-on-window-close" type="b">
+			<summary>Hide the window instead of closing it when the window close button (X) is activated.</summary>
+			<default>false</default>
+		</key>
 
 		<child name="saved-state" schema="org.perezdecastro.Revolt.State"/>
 	</schema>

--- a/revolt/window.py
+++ b/revolt/window.py
@@ -30,6 +30,10 @@ class MainWindow(Gtk.ApplicationWindow):
 
         if application.settings.get_boolean("use-header-bar"):
             self.set_titlebar(self.__make_headerbar())
+
+        if application.settings.get_boolean("hide-on-window-close"):
+            self.connect("delete-event", self.__hide_on_destroy)
+
         self.set_title(u"Revolt")
         application.add_window(self)
         self._webview = WebKit2.WebView(user_content_manager=self._user_content_manager,
@@ -215,6 +219,10 @@ class MainWindow(Gtk.ApplicationWindow):
         self._webview.connect("show-notification", self.__on_show_notification)
         self._webview.connect("permission-request", self.__on_permission_request)
 
+    def __hide_on_destroy(self, widget, event):
+        self.hide()
+        return True
+
     def reload_riot(self, bypass_cache=False):
         if bypass_cache:
             self._webview.reload_bypass_cache()
@@ -232,7 +240,6 @@ class MainWindow(Gtk.ApplicationWindow):
         self._webview.load_uri(urlunsplit(url))
 
     def finish(self):
-        # TODO: Most likely this can be moved to do_destroy()
         self._webview.stop_loading()
         self.hide()
         self.destroy()


### PR DESCRIPTION
* This adds a new setting "hide-on-window-close", disabled by default.
* If this setting is enabled, then when the window close button (X) is
pressed the window will hide instead of closing.
* This is useful for desktops with a tray bar and a status icon, where
the user is used to close the program by selecting the quit option from
the contextual menu of the status icon instead of by closing the window.
* The setting can be toggled with:
```
  gsettings set org.perezdecastro.Revolt:/org/perezdecastro/Revolt/ hide-on-window-close true
```