### PR TITLE
Hide and restore the application window when clicking the status icon.

### DIFF
--- a/revolt/statusicon.py
+++ b/revolt/statusicon.py
@@ -265,4 +265,7 @@ class StatusIcon(object):
     # Delegate methods.
     def on_icon_activate(self, icon_impl):
         self.clear_notifications()
-        self.__app.show()
+        if self.__app.is_visible_and_focused():
+            self.__app.hide()
+        else:
+            self.__app.show()

--- a/revolt/window.py
+++ b/revolt/window.py
@@ -219,7 +219,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self._webview.connect("permission-request", self.__on_permission_request)
 
     def __hide_on_destroy(self, widget, event):
-        self.hide()
+        self.application.hide()
         return True
 
     def reload_riot(self, bypass_cache=False):


### PR DESCRIPTION
 * This makes the Revolt window hide and show when the user clicks on the
   status icon. It matches the behavior of other applications with status
   icons like `Gajim` or `Quassel`.

   - If the application window its focused, when the status icon is clicked,
     then the application window its hidden (not simply minimized).
     The window geometry and coordinates are saved for restoring later.

   - If the application window its hidden, when the status icon is clicked,
     then the application window its restored and bring to the front.
     It also restores the previous saved window properties (if any).

   - If the application window its minimized or not focused, then it simply
     brings it to the front when the status icon is clicked.