### PR TITLE
Upstream name change: Riot is now Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Revolt
 ======
 
-Revolt is a small application which wraps [Riot](https://riot.im) to provide
-better integration with desktop environments in general, and
+Revolt is a small application which wraps [Element](https://element.io) to
+provide better integration with desktop environments in general, and
 [GNOME](http://www.gnome.org) in particular:
 
-* Having Riot as a “standalone” application with its own window, launcher,
-  icon, etc. instead of it living in a browser tab.
+* Having Element as a “standalone” application with its own window,
+  launcher, icon, etc. instead of it living in a browser tab.
 * Persistent notifications (for desktop environments supporting them, i.e.
   GNOME). Notifications are automatically prevented when the Revolt window is
   focused.

--- a/gtk/menus.ui
+++ b/gtk/menus.ui
@@ -10,8 +10,8 @@
 				<attribute name="accel"><![CDATA[<Control>e]]></attribute>
 			</item>
 			<item>
-				<attribute name="label" translatable="yes">_Riot Settings</attribute>
-				<attribute name="action">app.riot-settings</attribute>
+				<attribute name="label" translatable="yes">_Element Settings</attribute>
+				<attribute name="action">app.element-settings</attribute>
 			</item>
 		</section>
 		<section>

--- a/gtk/preferences.ui
+++ b/gtk/preferences.ui
@@ -75,9 +75,9 @@
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Riot _URL</property>
+                                <property name="label" translatable="yes">Element _URL</property>
                                 <property name="use_underline">True</property>
-                                <property name="mnemonic_widget">riot-url-entry</property>
+                                <property name="mnemonic_widget">element-url-entry</property>
                                 <property name="track_visited_links">False</property>
                               </object>
                               <packing>
@@ -87,7 +87,7 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkEntry" id="riot-url-entry">
+                              <object class="GtkEntry" id="element-url-entry">
                                 <property name="width_request">250</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -353,7 +353,7 @@
   </object>
   <object class="GtkSizeGroup">
     <widgets>
-      <widget name="riot-url-entry"/>
+      <widget name="element-url-entry"/>
       <widget name="zoom-factor-scale"/>
     </widgets>
   </object>

--- a/org.perezdecastro.Revolt.appdata.xml
+++ b/org.perezdecastro.Revolt.appdata.xml
@@ -4,14 +4,14 @@
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-3.0</project_license>
 	<name>Revolt</name>
-	<summary>Better integration of Riot, a Matrix client, with desktop environments</summary>
+	<summary>Better integration of Element, a Matrix client, with desktop environments</summary>
 	<description>
 		<p>
-			Revolt is a small application which wraps Riot to provide better integration
+			Revolt is a small application which wraps Element to provide better integration
 			with desktop environments in general, and GNOME in particular:
 		</p>
 		<ul>
-			<li>Having Riot as a “standalone” application instead of it living in a browser tab</li>
+			<li>Having Element as a “standalone” application instead of it living in a browser tab</li>
 			<li>Persistent notifications (for desktop environments supporting them, i.e. GNOME)</li>
 			<li>Notifications are automatically prevented when the Revolt window is focused</li>
 			<li>Status icon for desktop environment which have a tray bar applet (XFCE, Budgie, likely many others)</li>

--- a/org.perezdecastro.Revolt.gschema.xml
+++ b/org.perezdecastro.Revolt.gschema.xml
@@ -2,8 +2,8 @@
 <schemalist>
 	<schema id="org.perezdecastro.Revolt">
 		<key name="riot-url" type="s">
-			<summary>Base URL of the Riot installation wrapped by Revolt</summary>
-			<default>"https://riot.im/app"</default>
+			<summary>Base URL of the Element installation wrapped by Revolt</summary>
+			<default>"https://app.element.io"</default>
 		</key>
 		<key name="zoom-factor" type="d">
 			<summary>Zoom factor applied to to application</summary>

--- a/revolt/accelerators.py
+++ b/revolt/accelerators.py
@@ -36,7 +36,7 @@ def __window_modify_zoom(accel_group, window, key, modifiers):
 
 
 def __window_webview_reload(accel_group, window, key, modifiers):
-    window.reload_riot(bypass_cache=True)
+    window.reload_element(bypass_cache=True)
 
 
 window_keys = Gtk.AccelGroup()

--- a/revolt/app.py
+++ b/revolt/app.py
@@ -15,7 +15,7 @@ from . import accelerators
 DEFAULT_APP_ID = "org.perezdecastro.Revolt"
 APP_ID = environ.get("REVOLT_OVERRIDE_APPLICATION_ID", DEFAULT_APP_ID).strip()
 
-APP_COMMENTS = u"Desktop application for Riot.im"
+APP_COMMENTS = u"Desktop application for Element.io"
 APP_WEBSITE = u"https://github.com/aperezdc/revolt"
 APP_AUTHORS = (u"Adrián Pérez de Castro <aperez@igalia.com>",
                u"Jacobo Aragunde Pérez <jaragunde@igalia.com>",
@@ -44,7 +44,7 @@ class RevoltApp(Gtk.Application):
                                  flags=Gio.ApplicationFlags.FLAGS_NONE)
         self.settings = Gio.Settings(schema_id=DEFAULT_APP_ID,
                                      path="/" + APP_ID.replace(".", "/") + "/")
-        self.riot_url = self.settings.get_string("riot-url")
+        self.element_url = self.settings.get_string("riot-url")
         self.window = None
         self._last_window_geometry = None
         self.statusicon = None
@@ -69,7 +69,7 @@ class RevoltApp(Gtk.Application):
         self.__action("quit", lambda *arg: self.quit())
         self.__action("about", self.__on_app_about)
         self.__action("preferences", self.on_app_preferences)
-        self.__action("riot-settings", self.on_riot_settings)
+        self.__action("element-settings", self.on_element_settings)
 
     def __on_shutdown(self, app):
         if self.window is not None:
@@ -81,7 +81,7 @@ class RevoltApp(Gtk.Application):
             saved_state_path += "saved-state/main-window/"
             saved_state = Gio.Settings(schema_id=DEFAULT_APP_ID + ".WindowState",
                                        path=saved_state_path)
-            self.window = MainWindow(self, saved_state).load_riot()
+            self.window = MainWindow(self, saved_state).load_element()
         self.show()
 
     def __on_app_about(self, action, param):
@@ -103,7 +103,7 @@ class RevoltApp(Gtk.Application):
         window, url_entry, zoom_factor, zoom_factor_reset, devtools_toggle = \
                 self._build("gtk/preferences.ui",
                             "settings-window",
-                            "riot-url-entry",
+                            "element-url-entry",
                             "zoom-factor",
                             "zoom-factor-reset",
                             "dev-tools-toggle")
@@ -113,20 +113,20 @@ class RevoltApp(Gtk.Application):
                            Gio.SettingsBindFlags.DEFAULT)
         zoom_factor_reset.connect("clicked", lambda button:
                                   self.settings.set_double("zoom-factor", 1.0))
-        url_entry.set_text(self.riot_url)
+        url_entry.set_text(self.element_url)
 
         def on_hide(window):
             new_url = url_entry.get_text()
-            if new_url != self.riot_url:
+            if new_url != self.element_url:
                 self.settings.set_string("riot-url", new_url)
-                self.riot_url = new_url
-                self.window.load_riot()
+                self.element_url = new_url
+                self.window.load_element()
         window.connect("hide", on_hide)
         window.add_accel_group(accelerators.window_close_on_escape)
         window.set_transient_for(self.window)
         window.present()
 
-    def on_riot_settings(self, action, param):
+    def on_element_settings(self, action, param):
         self.show()
         self.window.load_settings_page()
 

--- a/revolt/window.py
+++ b/revolt/window.py
@@ -127,7 +127,7 @@ class MainWindow(Gtk.ApplicationWindow):
         if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION:
             if decision.get_navigation_type() == WebKit2.NavigationType.LINK_CLICKED:
                 uri = decision.get_request().get_uri()
-                if not uri.startswith(self.application.riot_url):
+                if not uri.startswith(self.application.element_url):
                     show_uri(self, uri)
                     return True
         elif decision_type == WebKit2.PolicyDecisionType.NEW_WINDOW_ACTION:
@@ -142,9 +142,9 @@ class MainWindow(Gtk.ApplicationWindow):
         action = Gio.SimpleAction.new("preferences")
         action.connect("activate", self.application.on_app_preferences)
         action_list.append((action, "_Preferences"))
-        action = Gio.SimpleAction.new("riot-settings")
-        action.connect("activate", self.application.on_riot_settings)
-        action_list.append((action, "_Riot Settings"))
+        action = Gio.SimpleAction.new("element-settings")
+        action.connect("activate", self.application.on_element_settings)
+        action_list.append((action, "_Element Settings"))
         return tuple(action_list)
 
     def __on_context_menu(self, webview, menu, event, hit_test):
@@ -222,14 +222,14 @@ class MainWindow(Gtk.ApplicationWindow):
         self.application.hide()
         return True
 
-    def reload_riot(self, bypass_cache=False):
+    def reload_element(self, bypass_cache=False):
         if bypass_cache:
             self._webview.reload_bypass_cache()
         else:
             self._webview.reload()
 
-    def load_riot(self):
-        self._webview.load_uri(self.application.riot_url)
+    def load_element(self):
+        self._webview.load_uri(self.application.element_url)
         return self
 
     def load_settings_page(self):


### PR DESCRIPTION
I replaced `riot` by `element` throughout. This fixes #106.
Now that Riot is Element, the name Revolt has a historical origin :-).