### PR TITLE
Switch to GNOME SDK version 43

### DIFF
--- a/org.perezdecastro.Revolt.json
+++ b/org.perezdecastro.Revolt.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.perezdecastro.Revolt",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "43",
   "sdk": "org.gnome.Sdk",
   "command": "revolt",
   "finish-args": [


### PR DESCRIPTION
Updating the SDK requirements because the GNOME 41 runtime is no longer supported as of September 17, 2022.